### PR TITLE
Make sure feature.pm is only test.recommends, as is optional before 5.10

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+# git help shortlog
+<kentnl@cpan.org> <kentfredric@gmail.com>

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Make sure feature.pm is only "test.recommends", as is optional prior
+    to 5.10 (GH #4, kentnl)
 
 0.50      2014-03-14
         - micro optimization: _any() saves a dereference

--- a/dist.ini
+++ b/dist.ini
@@ -14,3 +14,8 @@ disable_trailing_whitespace_tests = 1
 
 [Prereqs]
 Safe = 2.30
+
+[Prereqs::Soften]
+to_relationship = recommends
+copy_to = develop.requires
+module = feature


### PR DESCRIPTION
This will reduce the number of things that go bang for things like cpanm that bail with test_requires not being satisfied. 