### PR TITLE
upgrade to aliased 0.33 to fix warning on perl 5.21

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,3 +14,4 @@ disable_trailing_whitespace_tests = 1
 
 [Prereqs]
 Safe = 2.30
+aliased = 0.33


### PR DESCRIPTION
perl 5.21.x has a new warning "Constants from lexical variables
potentially modified elsewhere are deprecated". This is fixed in aliased
version 0.33.

---

This issue creates a failing test in my project preaction/Statocles#190: http://www.cpantesters.org/cpan/report/ccc1cf40-8c71-11e4-b15b-1d0ce0bfc7aa