### PR TITLE
ignore uninitialize warnings when comparing the result of reftype in …

### DIFF
--- a/lib/Data/DPath/Filters.pm
+++ b/lib/Data/DPath/Filters.pm
@@ -66,6 +66,7 @@ sub reftype() {
 }
 
 sub is_reftype($) {
+        no warnings 'uninitialized';
         return (Scalar::Util::reftype($_) eq shift);
 }
 


### PR DESCRIPTION
…is_reftype

if the argument to reftype isn't a ref, it'll return undef and Perl
will squawk when the undef is compared to the is_reftype's passed
argument.