### PR TITLE
quiet experimental smartmatch warnings during testing

### DIFF
--- a/lib/Data/DPath/Context.pm
+++ b/lib/Data/DPath/Context.pm
@@ -201,7 +201,7 @@ sub _filter_points_eval
                                                        # on later Perls, ^W doesn't do the whole trick, so explicitly turn
                                                        # all warnings off.  need to do this in a BEGIN, as some warnings
                                                        # are compile time only.
-                                                       $res = $COMPARTMENT->reval('BEGIN{ local $^W; warnings->unimport}'.$filter);
+                                                       $res = $COMPARTMENT->reval('BEGIN{ warnings->unimport}; local $^W;'.$filter);
                                                } else {
                                                        # 'uninitialized' values are the norm
                                                        no warnings 'uninitialized';

--- a/lib/Data/DPath/Context.pm
+++ b/lib/Data/DPath/Context.pm
@@ -205,6 +205,7 @@ sub _filter_points_eval
                                                } else {
                                                        # 'uninitialized' values are the norm
                                                        no warnings 'uninitialized';
+						       no if $] >= 5.018, warnings => 'experimental::smartmatch';
                                                        $res = eval($filter);
                                                }
                                                print STDERR ($@, "\n") if $@;

--- a/lib/Data/DPath/Context.pm
+++ b/lib/Data/DPath/Context.pm
@@ -27,6 +27,9 @@ BEGIN {
 
         $COMPARTMENT = Safe->new;
         $COMPARTMENT->permit(qw":base_core");
+        $COMPARTMENT->permit(qw":load");
+        $COMPARTMENT->reval( 'no warnings;' ); # just so warnings is loaded
+        $COMPARTMENT->deny(qw":load");
         # map DPath filter functions into new namespace
         $COMPARTMENT->share(qw(affe
                                idx
@@ -194,8 +197,11 @@ sub _filter_points_eval
                                                        # 'uninitialized' values are the norm
                                                        # but "no warnings 'uninitialized'" does
                                                        # not work in this restrictive Safe.pm config, so
-                                                       # we deactivate warnings completely by localizing $^W
-                                                       $res = $COMPARTMENT->reval('local $^W;'.$filter);
+                                                       # we deactivate warnings completely by localizing $^W.
+                                                       # on later Perls, ^W doesn't do the whole trick, so explicitly turn
+                                                       # all warnings off.  need to do this in a BEGIN, as some warnings
+                                                       # are compile time only.
+                                                       $res = $COMPARTMENT->reval('BEGIN{ local $^W; warnings->unimport}'.$filter);
                                                } else {
                                                        # 'uninitialized' values are the norm
                                                        no warnings 'uninitialized';

--- a/t/data_dpath.t
+++ b/t/data_dpath.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+no if $] >= 5.018, warnings => 'experimental::smartmatch';
 
 use Test::More;
 use Test::Deep;

--- a/t/optimization.t
+++ b/t/optimization.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+no if $] >= 5.018, warnings => 'experimental::smartmatch';
 
 use Test::More;
 use Test::Deep;

--- a/t/regressions.t
+++ b/t/regressions.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+no if $] >= 5.018, warnings => 'experimental::smartmatch';
 
 use Test::More;
 use Test::Deep;

--- a/t/zeros.t
+++ b/t/zeros.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+no if $] >= 5.018, warnings => 'experimental::smartmatch';
 
 use Test::More;
 use Test::Deep;


### PR DESCRIPTION
This commit quiets most of the smartmatch warnings during testing.  There's still some coming out of the Safe compartment that I haven't figured out how to quell.