### PR TITLE
fix invalid optag on 5.8.9

### DIFF
--- a/lib/Data/DPath/Context.pm
+++ b/lib/Data/DPath/Context.pm
@@ -28,9 +28,9 @@ BEGIN {
 
         $COMPARTMENT = Safe->new;
         $COMPARTMENT->permit(qw":base_core");
-        $COMPARTMENT->permit(qw":load");
+        $COMPARTMENT->permit(qw"require dofile caller runcv");
         $COMPARTMENT->reval( 'no warnings;' ); # just so warnings is loaded
-        $COMPARTMENT->deny(qw":load");
+        $COMPARTMENT->deny(qw"require dofile caller runcv");
         # map DPath filter functions into new namespace
         $COMPARTMENT->share(qw(affe
                                idx


### PR DESCRIPTION
5.8.9 did not implement the ":load" optag, so we need to instead use the
underlying opcodes. This will not allow new opcodes, but we have
a choice to either support 5.10 as a minimum, or not use the 5.10
optag...

On Perl 5.8.9, I get the following error:

> Unknown operator tag ":load" at /home/travis/perl5/perlbrew/perls/5.8.9/lib/5.8.9/x86_64-linux/Safe.pm line 258.
https://travis-ci.org/preaction/Beam-Runner/jobs/245003827#L396-L397

According to `perldoc Opcode`, the ":load" tag is made up of the opcodes: require dofile caller runcv. I think if we use the opcodes instead of the tag, we can fix this behavior.