### PR TITLE
use uniqnum from List::Util

### DIFF
--- a/lib/Data/DPath/Context.pm
+++ b/lib/Data/DPath/Context.pm
@@ -7,11 +7,10 @@ use warnings;
 use Data::Dumper;
 use aliased 'Data::DPath::Point';
 use aliased 'Data::DPath::Attrs';
-use List::MoreUtils 'uniq';
 use Scalar::Util 'reftype';
 use Data::DPath::Filters;
 use Iterator::Util;
-use List::Util 'min';
+use List::Util 1.45 'min', 'uniqnum';
 #use Sys::CPU;
 use POSIX ();
 use Safe;
@@ -167,7 +166,7 @@ sub _all_ref {
 
         return [
                 map { $self->give_references ? $_ : $$_ }
-                uniq
+                uniqnum
                 map { defined $_ ? $_->ref : () }
                 @{$self->current_points}
             ];


### PR DESCRIPTION
List::MoreUtils has a wacky packaging situation so it is best avoided, and uniq is now provided by List::Util in 1.45. Also, changed to use the related uniqnum instead, because it is uniq-ing defined scalar references (as far as I can tell), and the numeric representation of a reference (the refaddr) is simpler to work with.