### PR TITLE
add idx accessor to Attrs class; should have been added in 0.56

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
 
+  - 'idx' attribute added in 0.56 was not added to Data::DPath::Attrs,
+    so didn't acquire an accessor.
+
 0.57      2017-08-18
   - polished Safe.pm handling to cooperate with older Perl and other modules
     in particular Test::Exception [Doug Bell, Jonathan William Taylor]

--- a/lib/Data/DPath/Attrs.pm
+++ b/lib/Data/DPath/Attrs.pm
@@ -7,7 +7,7 @@ use warnings;
 use Class::XSAccessor # ::Array
     chained     => 1,
     constructor => 'new',
-    accessors   => [qw( key )];
+    accessors   => [qw( key idx )];
 
 1;
 

--- a/t/iterator.t
+++ b/t/iterator.t
@@ -131,7 +131,7 @@ while ($benchmarks->isnt_exhausted)
 
                     my $j = 0;
                     while ( $iter->isnt_exhausted ) {
-                        my $idx_got = $iter->value->first_point->attrs->{idx};
+                        my $idx_got = $iter->value->first_point->attrs->idx;
                         is( $idx_got, $idx_exp, "idx attr $i.$j" );
                     }
                     continue {


### PR DESCRIPTION
Point attribute `idx` was not added to the `Attrs` class, thus didn't get a proper accessor.