### PR TITLE
avoid smartmatch for most tests

### DIFF
--- a/t/data_dpath.t
+++ b/t/data_dpath.t
@@ -232,22 +232,6 @@ cmp_bag(\@resultlist, [ $data ], "ROOT" );
 @resultlist = dpath('/AAA/*/CCC')->match($data);
 cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "KEYs + ANYSTEP" );
 
-# --- same with operator ---
-
-cmp_bag($data ~~ dpath('/AAA/BBB/CCC'),    [ ['XXX', 'YYY', 'ZZZ'] ], "KEYs" );
-cmp_bag($data ~~ dpath('/AAA/BBB/CCC/..'), [ { CCC => ['XXX', 'YYY', 'ZZZ'] } ], "KEYs + PARENT" );
-cmp_bag($data ~~ dpath('/AAA/BBB/CCC/../..'), [
-                                                 {
-                                                  BBB => { CCC => ['XXX', 'YYY', 'ZZZ'] },
-                                                  RRR => { CCC  => [ qw/ RR1 RR2 RR3 / ] },
-                                                  DDD => { EEE => [ qw/ uuu vvv www / ] },
-                                                 }
-                                                ], "KEYs + PARENT + PARENT" );
-cmp_bag($data ~~ dpath('/AAA/BBB/CCC/../../DDD'), [ { EEE => [ qw/ uuu vvv www / ] } ], "KEYs + PARENT + KEY" );
-cmp_bag($data ~~ dpath('/AAA/*/CCC/../../DDD'), [ { EEE => [ qw/ uuu vvv www / ] } ], "KEYs + ANYSTEP + PARENT + KEY no double results" );
-cmp_bag($data ~~ dpath('/'), [ $data ], "ROOT" );
-cmp_bag($data ~~ dpath('/AAA/*/CCC'), [ ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "KEYs + ANYSTEP" );
-
 # --- ---
 
 @resultlist = dpath('//AAA/*/CCC')->match($data);
@@ -265,43 +249,25 @@ cmp_bag(\@resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ]
 
 # --------------------
 
-$resultlist = $data ~~ dpath '/some//CCC';
-cmp_bag($resultlist, [ 'affe' ], "ROOT + ANYWHERE + KEY + KEY" );
+@resultlist = dpath('/some//CCC')->match($data);
+cmp_bag(\@resultlist, [ 'affe' ], "ROOT + ANYWHERE + KEY + KEY" );
 
-$resultlist = $data ~~ dpath '//some//CCC';
-cmp_bag($resultlist, [ 'affe' ], "ANYWHERE + KEY + ANYWHERE + KEY" );
+@resultlist = dpath('//some//CCC')->match($data);
+cmp_bag(\@resultlist, [ 'affe' ], "ANYWHERE + KEY + ANYWHERE + KEY" );
 
-$resultlist = $data ~~ dpath '/some//else//CCC';
-cmp_bag($resultlist, [ 'affe' ], "ROOT + KEY + ANYWHEREs + KEY" );
+@resultlist = dpath('/some//else//CCC')->match($data);
+cmp_bag(\@resultlist, [ 'affe' ], "ROOT + KEY + ANYWHEREs + KEY" );
 
-$resultlist = $data ~~ dpath '//some//else//CCC';
-cmp_bag($resultlist, [ 'affe' ], "ANYWHERE + KEYs + ANYWHEREs" );
+@resultlist = dpath('//some//else//CCC')->match($data);
+cmp_bag(\@resultlist, [ 'affe' ], "ANYWHERE + KEYs + ANYWHEREs" );
 
-$resultlist = $data ~~ dpathr '//some//else//CCC';
-cmp_bag($resultlist, [ \($data->{some}{where}{else}{AAA}{BBB}{CCC}) ], "ANYWHERE + KEYs + ANYWHEREs (REFERENCES)" );
+@resultlist = dpathr('//some//else//CCC')->match($data);
+cmp_bag(\@resultlist, [ \($data->{some}{where}{else}{AAA}{BBB}{CCC}) ], "ANYWHERE + KEYs + ANYWHEREs (REFERENCES)" );
 
 # --------------------
 
-my $dpath = dpath('//AAA/*/CCC');
-$resultlist = $data ~~ $dpath;
-cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "ANYWHERE + KEYs + ANYSTEP with smartmatch and variable" );
-$dpath = dpath('///AAA/*/CCC');
-$resultlist = $data ~~ $dpath;
-cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "2xANYWHERE + KEYs + ANYSTEP with smartmatch and variable" );
-
-$resultlist = $data ~~ dpath('//AAA/*/CCC');
-cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "ANYWHERE + KEYs + ANYSTEP with smartmatch and dpath()" );
-$resultlist = $data ~~ dpath('///AAA/*/CCC');
-cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "2xANYWHERE + KEYs + ANYSTEP with smartmatch and dpath()" );
-
-$resultlist = $data ~~ dpathr('///AAA/*/CCC');
-cmp_bag($resultlist, [ \($data->{some}{where}{else}{AAA}{BBB}{CCC}),
-                       \($data->{AAA}{BBB}{CCC}),
-                       \($data->{AAA}{RRR}{CCC}),
-                     ], "2xANYWHERE + KEYs + ANYSTEP with smartmatch and dpath() (REFERENCES)" );
-
-$resultlist = $data ~~ dpath('//AAA');
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA')->match($data);
+cmp_bag(\@resultlist, [
                       {
                        BBB => { CCC  => [ qw/ XXX YYY ZZZ / ] },
                        RRR => { CCC  => [ qw/ RR1 RR2 RR3 / ] },
@@ -310,39 +276,39 @@ cmp_bag($resultlist, [
                       { BBB => { CCC => 'affe' } },
                      ], "ANYWHERE + KEY" );
 
-$resultlist = $data ~~ dpath('//AAA/*');
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*')->match($data);
+cmp_bag(\@resultlist, [
                       { CCC  => [ qw/ XXX YYY ZZZ / ] },
                       { CCC  => [ qw/ RR1 RR2 RR3 / ] },
                       { EEE  => [ qw/ uuu vvv www / ] },
                       { CCC => 'affe' },
                      ], "ANYWHERE + KEY + ANYSTEP" );
 
-$resultlist = $data ~~ dpath('//AAA/*[size == 3]');
-cmp_bag($resultlist, [ ], "ANYWHERE + KEY + ANYSTEP + FILTER size" );
+@resultlist = dpath('//AAA/*[size == 3]')->match($data);
+cmp_bag(\@resultlist, [ ], "ANYWHERE + KEY + ANYSTEP + FILTER size" );
 
-$resultlist = $data ~~ dpath('//AAA[size == 3]');
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA[size == 3]')->match($data);
+cmp_bag(\@resultlist, [
                       { BBB   => { CCC  => [ qw/ XXX YYY ZZZ / ] },
                         RRR   => { CCC  => [ qw/ RR1 RR2 RR3 / ] },
                         DDD   => { EEE  => [ qw/ uuu vvv www / ] },
                       }
                      ], "ANYWHERE + KEY + FILTER size == 3" );
 
-$resultlist = $data ~~ dpath('//AAA[size != 3]');
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA[size != 3]')->match($data);
+cmp_bag(\@resultlist, [
                       { BBB => { CCC => 'affe' } }
                      ], "ANYWHERE + KEY + FILTER size != 3" );
 
-$resultlist = $data ~~ dpath('//AAA/*/*[size == 3]');
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*/*[size == 3]')->match($data);
+cmp_bag(\@resultlist, [
                       [ qw/ XXX YYY ZZZ / ],
                       [ qw/ RR1 RR2 RR3 / ],
                       [ qw/ uuu vvv www / ],
                      ], "ANYWHERE + KEY + ANYSTEP + FILTER size" );
 
-$resultlist = $data ~~ dpath('//.[size == 3]');
-cmp_bag($resultlist, [
+@resultlist = dpath('//.[size == 3]')->match($data);
+cmp_bag(\@resultlist, [
                       $data,
                       $data->{AAA},
                       [ qw/ XXX YYY ZZZ / ],
@@ -350,42 +316,32 @@ cmp_bag($resultlist, [
                       [ qw/ uuu vvv www / ],
                      ], "ANYWHERE + FILTER size" );
 
-$resultlist = $data ~~ dpath('//AAA/*[size == 1]');
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*[size == 1]')->match($data);
+cmp_bag(\@resultlist, [
                       { CCC  => [ qw/ XXX YYY ZZZ / ] },
                       { CCC  => [ qw/ RR1 RR2 RR3 / ] },
                       { EEE  => [ qw/ uuu vvv www / ] },
                       { CCC => 'affe' },
                      ], "ANYWHERE + KEY + ANYSTEP + FILTER size" );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC';
-cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "ANYWHERE + KEYs + ANYSTEP with smartmatch and dpath without parens" );
-$resultlist = $data ~~ dpath '///AAA/*/CCC';
-cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "2xANYWHERE + KEYs + ANYSTEP with smartmatch and dpath without parens" );
+@resultlist = dpath('/AAA/*/CCC/*')->match($data);
+cmp_bag(\@resultlist, [ 'XXX', 'YYY', 'ZZZ', 'RR1', 'RR2', 'RR3' ], "trailing .../* unpacks" );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC';
-cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "ANYWHERE + KEYs + ANYSTEP with smartmatch and dpath without parens commutative" );
-$resultlist = $data ~~ dpath '///AAA/*/CCC';
-cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "2xANYWHERE + KEYs + ANYSTEP with smartmatch and dpath without parens commutative" );
+@resultlist = dpath('/strange_keys/DD DD/"EE/E"/CCC')->match($data);
+@resultlist = dpath('/strange_keys/"DD DD"/"EE/E"/CCC')->match($data);
+cmp_bag(\@resultlist, [ 'zomtec' ], "quoted KEY containg slash" );
 
-$resultlist = $data ~~ dpath '/AAA/*/CCC/*';
-cmp_bag($resultlist, [ 'XXX', 'YYY', 'ZZZ', 'RR1', 'RR2', 'RR3' ], "trailing .../* unpacks" );
+@resultlist = dpath('//AAA/*/CCC[size == 3]')->match($data); # array with 3 elements
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], 'FILTER size == 3' );
 
-$resultlist = $data ~~ dpath '/strange_keys/DD DD/"EE/E"/CCC';
-$resultlist = $data ~~ dpath '/strange_keys/"DD DD"/"EE/E"/CCC';
-cmp_bag($resultlist, [ 'zomtec' ], "quoted KEY containg slash" );
+@resultlist = dpath('//AAA/*/CCC[size == 1]')->match($data); # array with 1 elements
+cmp_bag(\@resultlist, [ 'affe' ], 'FILTER size == 1' );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC[size == 3]'; # array with 3 elements
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], 'FILTER size == 3' );
+@resultlist = dpath('//AAA/*/CCC[size >= 1]')->match($data); # array with >= elements
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ], 'affe' ], 'FILTER size >= 1' );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC[size == 1]'; # array with 1 elements
-cmp_bag($resultlist, [ 'affe' ], 'FILTER size == 1' );
-
-$resultlist = $data ~~ dpath '//AAA/*/CCC[size >= 1]'; # array with >= elements
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ], 'affe' ], 'FILTER size >= 1' );
-
-$resultlist = $data ~~ dpath '/AAA[size == 3]'; # hash with >= elements
-cmp_bag($resultlist, [
+@resultlist = dpath('/AAA[size == 3]')->match($data); # hash with >= elements
+cmp_bag(\@resultlist, [
                       {
                        BBB => { CCC  => [ qw/ XXX YYY ZZZ / ] },
                        RRR => { CCC  => [ qw/ RR1 RR2 RR3 / ] },
@@ -393,11 +349,11 @@ cmp_bag($resultlist, [
                       }
                      ], 'FILTER hash size == 3' );
 
-$resultlist = $data ~~ dpath '/AAA[size != 3]'; # hash with keys
-cmp_bag($resultlist, [ ], 'FILTER hash size != 3' );
+@resultlist = dpath('/AAA[size != 3]')->match($data); # hash with keys
+cmp_bag(\@resultlist, [ ], 'FILTER hash size != 3' );
 
-$resultlist = $data ~~ dpath '//AAA[size >= 1]'; # hash with >= elements
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA[size >= 1]')->match($data); # hash with >= elements
+cmp_bag(\@resultlist, [
                       {
                        BBB => { CCC  => [ qw/ XXX YYY ZZZ / ] },
                        RRR => { CCC  => [ qw/ RR1 RR2 RR3 / ] },
@@ -406,8 +362,8 @@ cmp_bag($resultlist, [
                       { BBB => { CCC => 'affe' } },
                      ], 'FILTER hash size >= 1' );
 
-$resultlist = $data ~~ dpath '//AAA[ size >= 3 ]'; # hash with >= 3 elements
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA[ size >= 3 ]')->match($data); # hash with >= 3 elements
+cmp_bag(\@resultlist, [
                       {
                        BBB => { CCC  => [ qw/ XXX YYY ZZZ / ] },
                        RRR => { CCC  => [ qw/ RR1 RR2 RR3 / ] },
@@ -415,75 +371,75 @@ cmp_bag($resultlist, [
                       },
                      ], 'FILTER hash size >= 3' );
 
-$resultlist = $data ~~ dpath '//AAA[size == 1]'; # hash with >= elements
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA[size == 1]')->match($data); # hash with >= elements
+cmp_bag(\@resultlist, [
                       { BBB => { CCC => 'affe' } },
                      ], 'ANYWHERE + FILTER hash size == 1' );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC/*';
-cmp_bag($resultlist, [ 'affe', 'XXX', 'YYY', 'ZZZ', 'RR1', 'RR2', 'RR3' ] );
+@resultlist = dpath('//AAA/*/CCC/*')->match($data);
+cmp_bag(\@resultlist, [ 'affe', 'XXX', 'YYY', 'ZZZ', 'RR1', 'RR2', 'RR3' ] );
 
 TODO: {
 
         local $TODO = 'far away future spec';
 
-        $resultlist = $data ~~ dpath '/AAA/*/CCC/* | /some/where/else/AAA/BBB/CCC';
+        @resultlist = dpath('/AAA/*/CCC/* | /some/where/else/AAA/BBB/CCC')->match($data);
         # ( 'XXX', 'YYY', 'ZZZ', 'affe' )
-        cmp_bag($resultlist, [ 'XXX', 'YYY', 'ZZZ', 'RR1', 'RR2', 'RR3', 'affe' ] );
+        cmp_bag(\@resultlist, [ 'XXX', 'YYY', 'ZZZ', 'RR1', 'RR2', 'RR3', 'affe' ] );
 
 }
 
-$resultlist = $data ~~ dpath '/AAA/*/CCC/*[0]';
-cmp_bag($resultlist, [ 'XXX', 'RR1' ], "ANYSTEP + FILTER int 0" );
-$resultlist = $data ~~ dpath '/AAA/*/CCC/*[ 0 ]';
-cmp_bag($resultlist, [ 'XXX', 'RR1' ], "ANYSTEP + FILTER int 0 whitespace" );
+@resultlist = dpath('/AAA/*/CCC/*[0]')->match($data);
+cmp_bag(\@resultlist, [ 'XXX', 'RR1' ], "ANYSTEP + FILTER int 0" );
+@resultlist = dpath('/AAA/*/CCC/*[ 0 ]')->match($data);
+cmp_bag(\@resultlist, [ 'XXX', 'RR1' ], "ANYSTEP + FILTER int 0 whitespace" );
 
-$resultlist = $data ~~ dpath '/AAA/*/CCC/*[2]';
-cmp_bag($resultlist, [ 'ZZZ', 'RR3' ], "ANYSTEP + FILTER int 2" );
-$resultlist = $data ~~ dpath '/AAA/*/CCC/*[ 2 ]';
-cmp_bag($resultlist, [ 'ZZZ', 'RR3' ], "ANYSTEP + FILTER int 2 whitespace" );
+@resultlist = dpath('/AAA/*/CCC/*[2]')->match($data);
+cmp_bag(\@resultlist, [ 'ZZZ', 'RR3' ], "ANYSTEP + FILTER int 2" );
+@resultlist = dpath('/AAA/*/CCC/*[ 2 ]')->match($data);
+cmp_bag(\@resultlist, [ 'ZZZ', 'RR3' ], "ANYSTEP + FILTER int 2 whitespace" );
 
-$resultlist = $data ~~ dpath '/AAA/*/CCC/*[-1]';
-cmp_bag($resultlist, [ 'ZZZ', 'RR3' ], "ANYSTEP + FILTER int -1" );
-$resultlist = $data ~~ dpath '/AAA/*/CCC/*[ -1 ]';
-cmp_bag($resultlist, [ 'ZZZ', 'RR3' ], "ANYSTEP + FILTER int -1 whitespace" );
+@resultlist = dpath('/AAA/*/CCC/*[-1]')->match($data);
+cmp_bag(\@resultlist, [ 'ZZZ', 'RR3' ], "ANYSTEP + FILTER int -1" );
+@resultlist = dpath('/AAA/*/CCC/*[ -1 ]')->match($data);
+cmp_bag(\@resultlist, [ 'ZZZ', 'RR3' ], "ANYSTEP + FILTER int -1 whitespace" );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC/*[0]';
-cmp_bag($resultlist, [ 'XXX', 'RR1', 'affe' ], "ANYWHERE + ANYSTEP + FILTER int 0" );
-$resultlist = $data ~~ dpath '//AAA/*/CCC/*[ 0 ]';
-cmp_bag($resultlist, [ 'XXX', 'RR1', 'affe' ], "ANYWHERE + ANYSTEP + FILTER int 0 whitespace" );
+@resultlist = dpath('//AAA/*/CCC/*[0]')->match($data);
+cmp_bag(\@resultlist, [ 'XXX', 'RR1', 'affe' ], "ANYWHERE + ANYSTEP + FILTER int 0" );
+@resultlist = dpath('//AAA/*/CCC/*[ 0 ]')->match($data);
+cmp_bag(\@resultlist, [ 'XXX', 'RR1', 'affe' ], "ANYWHERE + ANYSTEP + FILTER int 0 whitespace" );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC/*[-3]';
-cmp_bag($resultlist, [ 'XXX', 'RR1', ], "ANYWHERE + ANYSTEP + FILTER int -3" );
-$resultlist = $data ~~ dpath '//AAA/*/CCC/*[ -3 ]';
-cmp_bag($resultlist, [ 'XXX', 'RR1', ], "ANYWHERE + ANYSTEP + FILTER int -3 whitespace" );
+@resultlist = dpath('//AAA/*/CCC/*[-3]')->match($data);
+cmp_bag(\@resultlist, [ 'XXX', 'RR1', ], "ANYWHERE + ANYSTEP + FILTER int -3" );
+@resultlist = dpath('//AAA/*/CCC/*[ -3 ]')->match($data);
+cmp_bag(\@resultlist, [ 'XXX', 'RR1', ], "ANYWHERE + ANYSTEP + FILTER int -3 whitespace" );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC/*[2]';
-cmp_bag($resultlist, [ 'ZZZ', 'RR3' ], "ANYWHERE + ANYSTEP + FILTER int 2" );
-$resultlist = $data ~~ dpath '//AAA/*/CCC/*[ 2 ]';
-cmp_bag($resultlist, [ 'ZZZ', 'RR3' ], "ANYWHERE + ANYSTEP + FILTER int 2 whitespace" );
+@resultlist = dpath('//AAA/*/CCC/*[2]')->match($data);
+cmp_bag(\@resultlist, [ 'ZZZ', 'RR3' ], "ANYWHERE + ANYSTEP + FILTER int 2" );
+@resultlist = dpath('//AAA/*/CCC/*[ 2 ]')->match($data);
+cmp_bag(\@resultlist, [ 'ZZZ', 'RR3' ], "ANYWHERE + ANYSTEP + FILTER int 2 whitespace" );
 
-$resultlist = $data ~~ dpath '/AAA/*/CCC[2]';
-cmp_bag($resultlist, [ ], "KEY + FILTER int" );
+@resultlist = dpath('/AAA/*/CCC[2]')->match($data);
+cmp_bag(\@resultlist, [ ], "KEY + FILTER int" );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC[2]';
-cmp_bag($resultlist, [ ], "ANYWHERE + KEY + FILTER int" );
+@resultlist = dpath('//AAA/*/CCC[2]')->match($data);
+cmp_bag(\@resultlist, [ ], "ANYWHERE + KEY + FILTER int" );
 
 
-$resultlist = $data ~~ dpath '/AAA/*/CCC[0]';
-#diag Dumper($resultlist);
-cmp_bag($resultlist, [ [ 'XXX', 'YYY', 'ZZZ' ], [ 'RR1', 'RR2', 'RR3' ] ], "KEY + FILTER int 0" );
+@resultlist = dpath('/AAA/*/CCC[0]')->match($data);
+#diag Dumper(\@resultlist);
+cmp_bag(\@resultlist, [ [ 'XXX', 'YYY', 'ZZZ' ], [ 'RR1', 'RR2', 'RR3' ] ], "KEY + FILTER int 0" );
 
-$resultlist = $data ~~ dpath '/AAA/*/CCC[1]';
-cmp_bag($resultlist, [ ], "KEY + FILTER int 1" );
+@resultlist = dpath('/AAA/*/CCC[1]')->match($data);
+cmp_bag(\@resultlist, [ ], "KEY + FILTER int 1" );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC[0]';
-#diag Dumper($resultlist);
-cmp_bag($resultlist, [ [ 'XXX', 'YYY', 'ZZZ' ], [ 'RR1', 'RR2', 'RR3' ], 'affe' ], "ANYWHERE + KEY + FILTER int 0" );
+@resultlist = dpath('//AAA/*/CCC[0]')->match($data);
+#diag Dumper(\@resultlist);
+cmp_bag(\@resultlist, [ [ 'XXX', 'YYY', 'ZZZ' ], [ 'RR1', 'RR2', 'RR3' ], 'affe' ], "ANYWHERE + KEY + FILTER int 0" );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC[1]';
-#diag Dumper($resultlist);
-cmp_bag($resultlist, [ ], "ANYWHERE + KEY + FILTER int 1" );
+@resultlist = dpath('//AAA/*/CCC[1]')->match($data);
+#diag Dumper(\@resultlist);
+cmp_bag(\@resultlist, [ ], "ANYWHERE + KEY + FILTER int 1" );
 
 # ----------------------------------------
 
@@ -495,14 +451,14 @@ my $data2 = [
               AAA  => { BBB   => { CCC  => [ qw/ XXX YYY ZZZ / ] } } },
             ];
 
-$resultlist = $data2 ~~ dpath '/*'; # /*
-cmp_bag($resultlist, [ 'UUU', 'VVV', 'WWW', { AAA  => { BBB   => { CCC  => [ qw/ XXX YYY ZZZ / ] } } } ], "ROOT + ANYSTEP" );
+@resultlist = dpath('/*')->match($data2); # /*
+cmp_bag(\@resultlist, [ 'UUU', 'VVV', 'WWW', { AAA  => { BBB   => { CCC  => [ qw/ XXX YYY ZZZ / ] } } } ], "ROOT + ANYSTEP" );
 
-$resultlist = $data2 ~~ dpath '/';
-cmp_bag($resultlist, [ $data2 ], "ROOT" );
+@resultlist = dpath('/')->match($data2);
+cmp_bag(\@resultlist, [ $data2 ], "ROOT" );
 
-$resultlist = $data2 ~~ dpath '//';
-cmp_bag($resultlist, [
+@resultlist = dpath('//')->match($data2);
+cmp_bag(\@resultlist, [
                       qw( UUU VVV WWW XXX YYY ZZZ ),
                       [ qw/ XXX YYY ZZZ / ],
                       { CCC => [ qw/ XXX YYY ZZZ / ] },
@@ -511,32 +467,32 @@ cmp_bag($resultlist, [
                       $data2,
                      ], "ANYWHERE" );
 
-$resultlist = $data2 ~~ dpath '//*[ size == 3 ]';
-cmp_bag($resultlist, [ [ qw/ XXX YYY ZZZ / ] ], "ANYWHERE + ANYSTEP + FILTER int" );
+@resultlist = dpath('//*[ size == 3 ]')->match($data2);
+cmp_bag(\@resultlist, [ [ qw/ XXX YYY ZZZ / ] ], "ANYWHERE + ANYSTEP + FILTER int" );
 
-$resultlist = $data2 ~~ dpath '/*[2]';
-cmp_bag($resultlist, [ 'WWW' ], "ROOT + ANYSTEP + FILTER int: plain value" );
+@resultlist = dpath('/*[2]')->match($data2);
+cmp_bag(\@resultlist, [ 'WWW' ], "ROOT + ANYSTEP + FILTER int: plain value" );
 
-$resultlist = $data2 ~~ dpath '/*[3]';
+@resultlist = dpath('/*[3]')->match($data2);
 # ( { AAA  => { BBB   => { CCC  => [ qw/ XXX YYY ZZZ / ] } } } )
-cmp_bag($resultlist, [ { AAA  => { BBB   => { CCC  => [ qw/ XXX YYY ZZZ / ] } } } ], "ROOT + ANYSTEP + FILTER int: ref value" );
+cmp_bag(\@resultlist, [ { AAA  => { BBB   => { CCC  => [ qw/ XXX YYY ZZZ / ] } } } ], "ROOT + ANYSTEP + FILTER int: ref value" );
 
-$resultlist = $data2 ~~ dpath '//*[2]';
-cmp_bag($resultlist, [ 'WWW', 'ZZZ' ], "ANYWHERE + ANYSTEP + FILTER int" );
+@resultlist = dpath('//*[2]')->match($data2);
+cmp_bag(\@resultlist, [ 'WWW', 'ZZZ' ], "ANYWHERE + ANYSTEP + FILTER int" );
 
 # basic eval filters
-$resultlist = $data2 ~~ dpath '/*/AAA/BBB/CCC';
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'] ], "FILTER eval prepare" );
-$resultlist = $data2 ~~ dpath '/*/AAA/BBB/CCC[17 == 17]';
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'] ], "FILTER eval simple true" );
-$resultlist = $data2 ~~ dpath '/*/AAA/BBB/CCC[0 == 0]';
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'] ], "FILTER eval simple true with false values" );
-$resultlist = $data2 ~~ dpath '/*/AAA/BBB/CCC["foo" eq "foo"]';
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'] ], "FILTER eval simple true with strings" );
-$resultlist = $data2 ~~ dpath '/*/AAA/BBB/CCC[1 == 2]';
-cmp_bag($resultlist, [ ], "FILTER eval simple false" );
-$resultlist = $data2 ~~ dpath '/*/AAA/BBB/CCC["foo" eq "bar"]';
-cmp_bag($resultlist, [ ], "FILTER eval simple false with strings" );
+@resultlist = dpath('/*/AAA/BBB/CCC')->match($data2);
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'] ], "FILTER eval prepare" );
+@resultlist = dpath('/*/AAA/BBB/CCC[17 == 17]')->match($data2);
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'] ], "FILTER eval simple true" );
+@resultlist = dpath('/*/AAA/BBB/CCC[0 == 0]')->match($data2);
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'] ], "FILTER eval simple true with false values" );
+@resultlist = dpath('/*/AAA/BBB/CCC["foo" eq "foo"]')->match($data2);
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'] ], "FILTER eval simple true with strings" );
+@resultlist = dpath('/*/AAA/BBB/CCC[1 == 2]')->match($data2);
+cmp_bag(\@resultlist, [ ], "FILTER eval simple false" );
+@resultlist = dpath('/*/AAA/BBB/CCC["foo" eq "bar"]')->match($data2);
+cmp_bag(\@resultlist, [ ], "FILTER eval simple false with strings" );
 
 # ----------------------------------------
 
@@ -579,121 +535,121 @@ my $data3  = {
 
 # ------------------------------
 
-$resultlist = $data3 ~~ dpath '//AAA/BBB/CCC';
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + KEYs in blessed structs" );
+@resultlist = dpath('//AAA/BBB/CCC')->match($data3);
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + KEYs in blessed structs" );
 
-$resultlist = $data3 ~~ dpath '//AAA//BBB/CCC';
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + ANYWHERE + KEYs in blessed structs" );
+@resultlist = dpath('//AAA//BBB/CCC')->match($data3);
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + ANYWHERE + KEYs in blessed structs" );
 
-$resultlist = $data3 ~~ dpath '//AAA//BBB//CCC';
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + ANYWHERE + ANYWHERE + KEYs in blessed structs" );
+@resultlist = dpath('//AAA//BBB//CCC')->match($data3);
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + ANYWHERE + ANYWHERE + KEYs in blessed structs" );
 
 SKIP: {
         skip "Filter functions with optional args are deprecated, use the is_XXX(args) form instead.", 1;
-        $resultlist = $data3 ~~ dpath '//AAA[ reftype("HASH") ]/BBB/CCC';
-        cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + FILTER reftype funcall + KEYs" );
+        @resultlist = dpath('//AAA[ reftype("HASH") ]/BBB/CCC')->match($data3);
+        cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + FILTER reftype funcall + KEYs" );
 }
 
-$resultlist = $data3 ~~ dpath '//AAA[ is_reftype("HASH") ]/BBB/CCC';
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + FILTER reftype funcall + KEYs" );
+@resultlist = dpath('//AAA[ is_reftype("HASH") ]/BBB/CCC')->match($data3);
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + FILTER reftype funcall + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//AAA[ reftype eq "HASH" ]/BBB/CCC';
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + FILTER reftype eq + KEYs" );
+@resultlist = dpath('//AAA[ reftype eq "HASH" ]/BBB/CCC')->match($data3);
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + FILTER reftype eq + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//AAA[ reftype =~ /ASH/ ]/BBB/CCC';
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + FILTER reftype smartmatch + KEYs" );
+@resultlist = dpath('//AAA[ reftype =~ /ASH/ ]/BBB/CCC')->match($data3);
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'], 'affe' ], "ANYWHERE + FILTER reftype regex + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//AAA[ isa("Foo::Bar") ]/BBB/CCC';
-cmp_bag($resultlist, [ ['XXX', 'YYY', 'ZZZ'] ], "ANYWHERE + FILTER isa + KEYs" );
+@resultlist = dpath('//AAA[ isa("Foo::Bar") ]/BBB/CCC')->match($data3);
+cmp_bag(\@resultlist, [ ['XXX', 'YYY', 'ZZZ'] ], "ANYWHERE + FILTER isa + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//DDD/EEE/F1[ value eq "affe" ]/../../FFF'; # the DDD/FFF where the neighbor DDD/EEE/F1 == "affe"
-cmp_bag($resultlist, [ 'interesting value' ], "ANYWHERE + KEYs + FILTER in blessed structs" );
+@resultlist = dpath('//DDD/EEE/F1[ value eq "affe" ]/../../FFF')->match($data3); # the DDD/FFF where the neighbor DDD/EEE/F1 == "affe"
+cmp_bag(\@resultlist, [ 'interesting value' ], "ANYWHERE + KEYs + FILTER in blessed structs" );
 
 # ------------------------------
 
-$resultlist = $data3 ~~ dpath '/neighbourhoods/*[0]/DDD/FFF';
+@resultlist = dpath('/neighbourhoods/*[0]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ROOT + KEYs + FILTER int 0 + KEYs" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ROOT + KEYs + FILTER int 0 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '/*[key =~ /neighbourhoods/]/*[0]/DDD/FFF';
+@resultlist = dpath('/*[key =~ /neighbourhoods/]/*[0]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + FILTER eval key matches + FILTER int 0 + KEYs" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + FILTER eval key matches + FILTER int 0 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '/*/.[key =~ /neighbourhoods/]/*[0]/DDD/FFF';
+@resultlist = dpath('/*/.[key =~ /neighbourhoods/]/*[0]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + NOSTEP + FILTER eval key matches + FILTER int 0 + KEYs" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + NOSTEP + FILTER eval key matches + FILTER int 0 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '/*/*/../.[key =~ /neighbourhoods/]/*[0]/DDD/FFF';
+@resultlist = dpath('/*/*/../.[key =~ /neighbourhoods/]/*[0]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + PARENT + NOSTEP + FILTER eval key matches + FILTER int 0 + KEYs" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + PARENT + NOSTEP + FILTER eval key matches + FILTER int 0 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '/neighbourhoods/*[1]/DDD/FFF';
+@resultlist = dpath('/neighbourhoods/*[1]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'boring value' ], "ROOT + KEYs + FILTER int 1 + KEYs" );
+cmp_bag(\@resultlist, [ 'boring value' ], "ROOT + KEYs + FILTER int 1 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//neighbourhoods/*[0]/DDD/FFF';
+@resultlist = dpath('//neighbourhoods/*[0]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ANYWHERE + KEYs + FILTER int 0 + KEYs" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ANYWHERE + KEYs + FILTER int 0 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//neighbourhoods/*[1]/DDD/FFF';
+@resultlist = dpath('//neighbourhoods/*[1]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'boring value' ], "ANYWHERE + KEYs + FILTER int 1 + KEYs" );
+cmp_bag(\@resultlist, [ 'boring value' ], "ANYWHERE + KEYs + FILTER int 1 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//neighbourhoods/*[2]/DDD/FFF';
+@resultlist = dpath('//neighbourhoods/*[2]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'third value' ], "ANYWHERE + KEYs + FILTER int 2 + KEYs" );
+cmp_bag(\@resultlist, [ 'third value' ], "ANYWHERE + KEYs + FILTER int 2 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//neighbourhoods/*[3]/DDD/FFF';
+@resultlist = dpath('//neighbourhoods/*[3]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'fourth value' ], "ANYWHERE + KEYs + FILTER int 3 + KEYs" );
+cmp_bag(\@resultlist, [ 'fourth value' ], "ANYWHERE + KEYs + FILTER int 3 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//neighbourhoods/*[-1]/DDD/FFF';
+@resultlist = dpath('//neighbourhoods/*[-1]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'fourth value' ], "ANYWHERE + KEYs + FILTER int -1 + KEYs" );
+cmp_bag(\@resultlist, [ 'fourth value' ], "ANYWHERE + KEYs + FILTER int -1 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//neighbourhoods/*[-2]/DDD/FFF';
+@resultlist = dpath('//neighbourhoods/*[-2]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'third value' ], "ANYWHERE + KEYs + FILTER int -2 + KEYs" );
+cmp_bag(\@resultlist, [ 'third value' ], "ANYWHERE + KEYs + FILTER int -2 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//neighbourhoods/*[-3]/DDD/FFF';
+@resultlist = dpath('//neighbourhoods/*[-3]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'boring value' ], "ANYWHERE + KEYs + FILTER int -3 + KEYs" );
+cmp_bag(\@resultlist, [ 'boring value' ], "ANYWHERE + KEYs + FILTER int -3 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//neighbourhoods/*[-4]/DDD/FFF';
+@resultlist = dpath('//neighbourhoods/*[-4]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ANYWHERE + KEYs + FILTER int -4 + KEYs" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ANYWHERE + KEYs + FILTER int -4 + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//neighbourhoods/*[-5]/DDD/FFF';
+@resultlist = dpath('//neighbourhoods/*[-5]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ ], "ANYWHERE + KEYs + FILTER too negative int + KEYs" );
+cmp_bag(\@resultlist, [ ], "ANYWHERE + KEYs + FILTER too negative int + KEYs" );
 
-$resultlist = $data3 ~~ dpath '//neighbourhoods/*[20]/DDD/FFF';
+@resultlist = dpath('//neighbourhoods/*[20]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ ], "ANYWHERE + KEYs + FILTER too high int + KEYs" );
+cmp_bag(\@resultlist, [ ], "ANYWHERE + KEYs + FILTER too high int + KEYs" );
 
-$resultlist = $data3 ~~ dpath '/*[key eq "neighbourhoods"]/*[0]/DDD/FFF';
+@resultlist = dpath('/*[key eq "neighbourhoods"]/*[0]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + FILTER eval key eq + FILTER int" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + FILTER eval key eq + FILTER int" );
 
-$resultlist = $data3 ~~ dpath '/*/.[key eq "neighbourhoods"]/*[0]/DDD/FFF';
+@resultlist = dpath('/*/.[key eq "neighbourhoods"]/*[0]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + NOSTEP + FILTER eval key eq + FILTER int" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + NOSTEP + FILTER eval key eq + FILTER int" );
 
-$resultlist = $data3 ~~ dpath '/*/*/../.[key eq "neighbourhoods"]/*[0]/DDD/FFF';
+@resultlist = dpath('/*/*/../.[key eq "neighbourhoods"]/*[0]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + PARENT + NOSTEP + FILTER eval key eq + FILTER int" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + PARENT + NOSTEP + FILTER eval key eq + FILTER int" );
 
-$resultlist = $data3 ~~ dpath '/*[key =~ /neigh.*hoods/]/*[0]/DDD/FFF';
+@resultlist = dpath('/*[key =~ /neigh.*hoods/]/*[0]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + FILTER eval key matches + FILTER int" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + FILTER eval key matches + FILTER int" );
 
-$resultlist = $data3 ~~ dpath '/*/.[key =~ /neigh.*hoods/]/*[0]/DDD/FFF';
+@resultlist = dpath('/*/.[key =~ /neigh.*hoods/]/*[0]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + NOSTEP + FILTER eval key matches + FILTER int" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + NOSTEP + FILTER eval key matches + FILTER int" );
 
-$resultlist = $data3 ~~ dpath '/*/*/../.[key =~ /neigh.*hoods/]/*[0]/DDD/FFF';
+@resultlist = dpath('/*/*/../.[key =~ /neigh.*hoods/]/*[0]/DDD/FFF')->match($data3);
 # ( 'interesting value' )
-cmp_bag($resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + PARENT + NOSTEP + FILTER eval key matches + FILTER int" );
+cmp_bag(\@resultlist, [ 'interesting value' ], "ROOT + ANYSTEP + PARENT + NOSTEP + FILTER eval key matches + FILTER int" );
 
 # ----------------------------------------
 
@@ -727,127 +683,127 @@ my $data4  = {
                                 ],
              };
 
-$resultlist = $data4 ~~ dpath '//AAA/BBB/CCC/*[ affe ]';
-cmp_bag($resultlist, [ 'affe' ], "FILTER: affe" );
+@resultlist = dpath('//AAA/BBB/CCC/*[ affe ]')->match($data4);
+cmp_bag(\@resultlist, [ 'affe' ], "FILTER: affe" );
 
-$resultlist = $data4 ~~ dpath '/AAA/BBB/CCC/*[ idx == 1 ]';
-cmp_bag($resultlist, [ 'YYY' ], "FILTER: index" );
+@resultlist = dpath('/AAA/BBB/CCC/*[ idx == 1 ]')->match($data4);
+cmp_bag(\@resultlist, [ 'YYY' ], "FILTER: index" );
 
-$resultlist = $data4 ~~ dpath '/AAA/BBB/CCC/*[ 1 ]';
-cmp_bag($resultlist, [ 'YYY' ], "FILTER: index" );
+@resultlist = dpath('/AAA/BBB/CCC/*[ 1 ]')->match($data4);
+cmp_bag(\@resultlist, [ 'YYY' ], "FILTER: index" );
 
-$resultlist = $data4 ~~ dpath '//AAA/BBB/CCC/*[ /..../ ]';
-cmp_bag($resultlist, [ 'XXXX', 'YYYY', 'ZZZZ', 'affe' ], "FILTER eval regex five chars" );
+@resultlist = dpath('//AAA/BBB/CCC/*[ /..../ ]')->match($data4);
+cmp_bag(\@resultlist, [ 'XXXX', 'YYYY', 'ZZZZ', 'affe' ], "FILTER eval regex five chars" );
 
-$resultlist = $data4 ~~ dpath '//AAA/BBB/CCC/*[ /[A-Z]+/ ]';
-cmp_bag($resultlist, [ 'XXX', 'YYY', 'ZZZ', 'XXXX', 'YYYY', 'ZZZZ', ], "FILTER eval regex just capitalizes" );
+@resultlist = dpath('//AAA/BBB/CCC/*[ /[A-Z]+/ ]')->match($data4);
+cmp_bag(\@resultlist, [ 'XXX', 'YYY', 'ZZZ', 'XXXX', 'YYYY', 'ZZZZ', ], "FILTER eval regex just capitalizes" );
 
 SKIP:
 {
         skip "quote semantics changed", 1;
-        $resultlist = $data4 ~~ dpath '//AAA/BBB/CCC/"*"[ m/[A-Z]+/ ]';
-        cmp_bag($resultlist, [ 'XXX', 'YYY', 'ZZZ', 'XXXX', 'YYYY', 'ZZZZ', ], "FILTER eval regex with quotes and slashes" );
+        @resultlist = dpath('//AAA/BBB/CCC/"*"[ m/[A-Z]+/ ]')->match($data4);
+        cmp_bag(\@resultlist, [ 'XXX', 'YYY', 'ZZZ', 'XXXX', 'YYYY', 'ZZZZ', ], "FILTER eval regex with quotes and slashes" );
 }
 
-$resultlist = $data ~~ dpath '//AAA/BBB/*[key eq "CCC"]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/BBB/*[key eq "CCC"]')->match($data);
+cmp_bag(\@resultlist, [
                       [ qw/ XXX YYY ZZZ / ],
                       'affe',
                      ], "ANYWHERE + STEP + ANYSTEP + FILTER eval key eq string" );
 
-$resultlist = $data ~~ dpath '//AAA/BBB/.[key eq "CCC"]';
-cmp_bag($resultlist, [ ], "ANYWHERE + STEP + NOSTEP + FILTER eval key eq string" );
+@resultlist = dpath('//AAA/BBB/.[key eq "CCC"]')->match($data);
+cmp_bag(\@resultlist, [ ], "ANYWHERE + STEP + NOSTEP + FILTER eval key eq string" );
 
-$resultlist = $data ~~ dpath '//AAA/*[ key eq "CCC" ]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*[ key eq "CCC" ]')->match($data);
+cmp_bag(\@resultlist, [
                      ], "ANYWHERE + ANYSTEP + FILTER eval key eq string" );
 
-$resultlist = $data ~~ dpath '//AAA/*/*[ key eq "CCC" ]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*/*[ key eq "CCC" ]')->match($data);
+cmp_bag(\@resultlist, [
                       [ qw/ XXX YYY ZZZ / ],
                       [ qw/ RR1 RR2 RR3 / ],
                       'affe',
                      ], "ANYWHERE + ANYSTEP + ANYSTEP + FILTER eval key eq string" );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC';
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*/CCC')->match($data);
+cmp_bag(\@resultlist, [
                       [ qw/ XXX YYY ZZZ / ],
                       [ qw/ RR1 RR2 RR3 / ],
                       'affe',
                      ], "ANYWHERE + STEP + ANYSTEP + STEP" );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC/.[ key eq "CCC" ]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*/CCC/.[ key eq "CCC" ]')->match($data);
+cmp_bag(\@resultlist, [
                       [ qw/ XXX YYY ZZZ / ],
                       [ qw/ RR1 RR2 RR3 / ],
                       'affe',
                      ], "ANYWHERE + STEP + ANYSTEP + STEP + FILTER eval key eq last STEP" );
 
-$resultlist = $data ~~ dpath '//.[ key eq "DD DD" ]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//.[ key eq "DD DD" ]')->match($data);
+cmp_bag(\@resultlist, [
                       { 'EE/E' => { CCC => 'zomtec' } }
                      ], "ANYWHERE + NOSTEP + FILTER eval key" );
 
-$resultlist = $data ~~ dpath '//.[ key eq "EE/E" ]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//.[ key eq "EE/E" ]')->match($data);
+cmp_bag(\@resultlist, [
                       { CCC => 'zomtec' }
                      ], "ANYWHERE + NOSTEP + FILTER eval key + slash in eval" );
 
-$resultlist = $data ~~ dpath '//AAA/*/CCC/.[ key eq "CCC" ]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*/CCC/.[ key eq "CCC" ]')->match($data);
+cmp_bag(\@resultlist, [
                       [ qw/ XXX YYY ZZZ / ],
                       [ qw/ RR1 RR2 RR3 / ],
                       'affe',
                      ], "ANYWHERE + STEP + ANYSTEP + STEP + FILTER eval key eq last STEP" );
 
-$resultlist = $data ~~ dpath '//AAA/*[ key =~ /.../ ]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*[ key =~ /.../ ]')->match($data);
+cmp_bag(\@resultlist, [
                       { CCC  => [ qw/ XXX YYY ZZZ / ] },
                       { CCC  => [ qw/ RR1 RR2 RR3 / ] },
                       { EEE  => [ qw/ uuu vvv www / ] },
                       { CCC => 'affe' },
                      ], "ANYWHERE + STEP + ANYSTEP + FILTER eval key matches" );
 
-$resultlist = $data ~~ dpath '//AAA/*[ key =~ qr(...) ]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*[ key =~ qr(...) ]')->match($data);
+cmp_bag(\@resultlist, [
                       { CCC  => [ qw/ XXX YYY ZZZ / ] },
                       { CCC  => [ qw/ RR1 RR2 RR3 / ] },
                       { EEE  => [ qw/ uuu vvv www / ] },
                       { CCC  => 'affe' },
                      ], "ROOT + ANYSTEP + FILTER eval key matches qr()" );
 
-$resultlist = $data ~~ dpath '//AAA/*[ key =~ m(...) ]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*[ key =~ m(...) ]')->match($data);
+cmp_bag(\@resultlist, [
                       { CCC  => [ qw/ XXX YYY ZZZ / ] },
                       { CCC  => [ qw/ RR1 RR2 RR3 / ] },
                       { EEE  => [ qw/ uuu vvv www / ] },
                       { CCC  => 'affe' },
                      ], "ROOT + ANYSTEP + FILTER eval with key matches m(...)" );
 
-$resultlist = $data ~~ dpath '//AAA/*[ key =~ /CC/ ]';
-cmp_bag($resultlist, [ ], "ROOT + ANYSTEP + FILTER eval with key matches /CC/" );
+@resultlist = dpath('//AAA/*[ key =~ /CC/ ]')->match($data);
+cmp_bag(\@resultlist, [ ], "ROOT + ANYSTEP + FILTER eval with key matches /CC/" );
 
-$resultlist = $data ~~ dpath '//AAA/*/*[ key =~ /CC/ ]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//AAA/*/*[ key =~ /CC/ ]')->match($data);
+cmp_bag(\@resultlist, [
                       [ qw/ XXX YYY ZZZ / ],
                       [ qw/ RR1 RR2 RR3 / ],
                       'affe',
                      ], "ROOT + ANYSTEP + ANYSTEP + FILTER eval with key matches /CC/" );
 
-$resultlist = $data ~~ dpath('//CCC/*[value eq "RR2"]');
-#print STDERR "resultlist = ", Dumper($resultlist);
-cmp_bag($resultlist, [ 'RR2' ], "ANYWHERE + ANYSTEP + FILTER eval value" );
+@resultlist = dpath('//CCC/*[value eq "RR2"]')->match($data);
+#print STDERR "resultlist = ", Dumper(\@resultlist);
+cmp_bag(\@resultlist, [ 'RR2' ], "ANYWHERE + ANYSTEP + FILTER eval value" );
 
 # print STDERR "**************************************************\n";
 # print STDERR "resultlist = ", Dumper($data ~~ dpath('//CCC/*[value eq "RR2"]')); # /..
-$resultlist = $data ~~ dpath('//CCC/*[value eq "RR2"]/..');
-#print STDERR "resultlist = ", Dumper($resultlist);
-cmp_bag($resultlist, [ [ 'RR1', 'RR2', 'RR3' ] ], "ANYWHERE + ANYSTEP + FILTER eval value + PARENT" );
+@resultlist = dpath('//CCC/*[value eq "RR2"]/..')->match($data);
+#print STDERR "resultlist = ", Dumper(\@resultlist);
+cmp_bag(\@resultlist, [ [ 'RR1', 'RR2', 'RR3' ] ], "ANYWHERE + ANYSTEP + FILTER eval value + PARENT" );
 # print STDERR "**************************************************\n";
 
-$resultlist = $data ~~ dpath('//CCC/*[value eq "RR2"]/../..');
-#print STDERR "resultlist = ", Dumper($resultlist);
-cmp_bag($resultlist, [ { CCC  => [ 'RR1', 'RR2', 'RR3' ] } ], "ANYWHERE + ANYSTEP + FILTER eval value + 2xPARENT" );
+@resultlist = dpath('//CCC/*[value eq "RR2"]/../..')->match($data);
+#print STDERR "resultlist = ", Dumper(\@resultlist);
+cmp_bag(\@resultlist, [ { CCC  => [ 'RR1', 'RR2', 'RR3' ] } ], "ANYWHERE + ANYSTEP + FILTER eval value + 2xPARENT" );
 
 # ----------------------------------------
 
@@ -863,8 +819,8 @@ my $data5 = {
                      },
             };
 
-$resultlist = $data5 ~~ dpath('/AAA/*/CCC');
-cmp_bag($resultlist, [ [ qw/ XXX YYY ZZZ / ],
+@resultlist = dpath('/AAA/*/CCC')->match($data5);
+cmp_bag(\@resultlist, [ [ qw/ XXX YYY ZZZ / ],
                        [ qw/ RR1 RR2 RR3 / ],
                        [ qw/ ASTAR BSTAR CSTAR / ],
                        [ qw/ ASLASH BSLASH CSLASH / ],
@@ -872,17 +828,17 @@ cmp_bag($resultlist, [ [ qw/ XXX YYY ZZZ / ],
                        [ qw/ ADOT BDOT CDOT / ],
                      ], "KEYs + ANYSTEP again" );
 
-$resultlist = $data5 ~~ dpath('/AAA/"*"/CCC');
-cmp_bag($resultlist, [ [ qw/ ASTAR BSTAR CSTAR / ] ], "KEYs + (*)" );
+@resultlist = dpath('/AAA/"*"/CCC')->match($data5);
+cmp_bag(\@resultlist, [ [ qw/ ASTAR BSTAR CSTAR / ] ], "KEYs + (*)" );
 
-$resultlist = $data5 ~~ dpath('/AAA/"//"/CCC');
-cmp_bag($resultlist, [ [ qw/ ASLASH BSLASH CSLASH / ] ], "KEYs + (//)" );
+@resultlist = dpath('/AAA/"//"/CCC')->match($data5);
+cmp_bag(\@resultlist, [ [ qw/ ASLASH BSLASH CSLASH / ] ], "KEYs + (//)" );
 
-$resultlist = $data5 ~~ dpath('/AAA/".."/CCC');
-cmp_bag($resultlist, [ [ qw/ ADOTDOT BDOTDOT CDOTDOT / ] ], "KEYs + (..)" );
+@resultlist = dpath('/AAA/".."/CCC')->match($data5);
+cmp_bag(\@resultlist, [ [ qw/ ADOTDOT BDOTDOT CDOTDOT / ] ], "KEYs + (..)" );
 
-$resultlist = $data5 ~~ dpath('/AAA/"."/CCC');
-cmp_bag($resultlist, [ [ qw/ ADOT BDOT CDOT / ] ], "KEYs + (.)" );
+@resultlist = dpath('/AAA/"."/CCC')->match($data5);
+cmp_bag(\@resultlist, [ [ qw/ ADOT BDOT CDOT / ] ], "KEYs + (.)" );
 
 # ----------------------------------------
 
@@ -902,29 +858,29 @@ my $data6 = bless [
                    },
                   ], "Some::Funky::Stuff";
 
-$resultlist = $data6 ~~ dpath '/.[ isa("Foo::Bar") ]';
-cmp_bag($resultlist, [ ], "ROOT + NOSTEP + FILTER isa (with no match)" );
+@resultlist = dpath('/.[ isa("Foo::Bar") ]')->match($data6);
+cmp_bag(\@resultlist, [ ], "ROOT + NOSTEP + FILTER isa (with no match)" );
 
-$resultlist = $data6 ~~ dpath '/.[ isa("Some::Funky::Stuff") ]';
-cmp_bag($resultlist, [ $data6 ], "ROOT + NOSTEP + FILTER isa" );
+@resultlist = dpath('/.[ isa("Some::Funky::Stuff") ]')->match($data6);
+cmp_bag(\@resultlist, [ $data6 ], "ROOT + NOSTEP + FILTER isa" );
 
 # chaining filters by using NOSTEP
 
-$resultlist = $data6 ~~ dpath '/.[ isa("Some::Funky::Stuff") ]/.[ size == 5 ]';
-cmp_bag($resultlist, [ $data6 ], "ROOT + NOSTEP + FILTER isa + FILTER size" );
+@resultlist = dpath('/.[ isa("Some::Funky::Stuff") ]/.[ size == 5 ]')->match($data6);
+cmp_bag(\@resultlist, [ $data6 ], "ROOT + NOSTEP + FILTER isa + FILTER size" );
 
-$resultlist = $data6 ~~ dpath '/.[ isa("Some::Funky::Stuff") ]/.[ size == 5 ]/.[ reftype eq "ARRAY" ]';
-cmp_bag($resultlist, [ $data6 ], "ROOT + NOSTEP + FILTER isa + FILTER size + FILTER reftype" );
+@resultlist = dpath('/.[ isa("Some::Funky::Stuff") ]/.[ size == 5 ]/.[ reftype eq "ARRAY" ]')->match($data6);
+cmp_bag(\@resultlist, [ $data6 ], "ROOT + NOSTEP + FILTER isa + FILTER size + FILTER reftype" );
 
-$resultlist = $data6 ~~ dpath '//.[ size == 4 ]';
-cmp_bag($resultlist, [
+@resultlist = dpath('//.[ size == 4 ]')->match($data6);
+cmp_bag(\@resultlist, [
                       [ 1, 2, 3, 4 ],
                       [ qw( AAA BBB CCC DDD ) ],
                       [ qw( affe tiger fink star ) ],
                      ], "ANYWHERE + NOSTEP + FILTER int" );
 
-$resultlist = $data6 ~~ dpath '//""/';
-cmp_bag($resultlist, [ "some value on empty key" ], "empty key");
+@resultlist = dpath('//""/')->match($data6);
+cmp_bag(\@resultlist, [ "some value on empty key" ], "empty key");
 
 my $data7 =  [
               [ 2, 3, 5, 7, 11, 13, 17, 19, 23 ],
@@ -941,17 +897,17 @@ my $data7 =  [
               },
              ];
 
-$resultlist = $data7 ~~ dpathr '//.[ size == 4 ]';
+@resultlist = dpathr('//.[ size == 4 ]')->match($data7);
 
-cmp_bag($resultlist, [
+cmp_bag(\@resultlist, [
                       \($data7->[1]),
                       \($data7->[2]),
                       \($data7->[4]{hot}{stuff}{ahead}),
                      ], "ANYWHERE + NOSTEP + FILTER int (REFERENCES)" );
 
-${$resultlist->[0]} = [ qw(one two three four) ];
-${$resultlist->[1]} = "there once was an array in LA";
-${$resultlist->[2]} = { affe => "tiger",
+${$resultlist[0]} = [ qw(one two three four) ];
+${$resultlist[1]} = "there once was an array in LA";
+${$resultlist[2]} = { affe => "tiger",
                         fink => "star",
                       };
 
@@ -971,7 +927,7 @@ my $data7_expected_change = [
                              },
                             ];
 
-# diag Dumper($resultlist);
+# diag Dumper(\@resultlist);
 # diag Dumper($data7_expected_change);
 # diag Dumper($data7);
 
@@ -995,18 +951,18 @@ my $data8 = {
 TODO: {
         local $TODO = "REAL TODO FIX ME SOON!";
 
-        $resultlist = $data8 ~~ dpath('//CCC//*[ value eq "RR3" ]/..'); # /../*[1]');
-        # print STDERR "resultlist = ", Dumper($resultlist);
-        cmp_bag($resultlist, [ [ 11, 22, 33 ] ], "ANYWHERE + ANYSTEP + FILTER eval value + PARENT + bless" );
+        @resultlist = dpath('//CCC//*[ value eq "RR3" ]/..')->match($data8); # /../*[1]');
+        # print STDERR "resultlist = ", Dumper(\@resultlist);
+        cmp_bag(\@resultlist, [ [ 11, 22, 33 ] ], "ANYWHERE + ANYSTEP + FILTER eval value + PARENT + bless" );
 
 }
 
 TODO: {
         local $TODO = "REAL TODO FIX ME SOON! (but depends on test before)";
 
-        $resultlist = $data8 ~~ dpath('//CCC//*[ value eq "RR3" ]/../../*[1]');
-        # print STDERR "resultlist = ", Dumper($resultlist);
-        cmp_bag($resultlist, [ [ 11, 22, 33 ] ], "ANYWHERE + ANYSTEP + FILTER eval value + 2xPARENT + FILTER int + bless" );
+        @resultlist = dpath('//CCC//*[ value eq "RR3" ]/../../*[1]')->match($data8);
+        # print STDERR "resultlist = ", Dumper(\@resultlist);
+        cmp_bag(\@resultlist, [ [ 11, 22, 33 ] ], "ANYWHERE + ANYSTEP + FILTER eval value + 2xPARENT + FILTER int + bless" );
 }
 
 done_testing();

--- a/t/optimization.t
+++ b/t/optimization.t
@@ -2,7 +2,6 @@
 
 use strict;
 use warnings;
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
 
 use Test::More;
 use Test::Deep;
@@ -11,13 +10,7 @@ use Data::Dumper;
 
 # local $Data::DPath::DEBUG = 1;
 
-BEGIN {
-        if ($] < 5.010) {
-                plan skip_all => "Perl 5.010 required for the smartmatch overloaded tests. This is ".$];
-        } else {
-                plan tests => 5;
-        }
-}
+plan tests => 5;
 
 use_ok( 'Data::DPath' );
 
@@ -34,10 +27,10 @@ my $data = $VAR1;
 
 my $res;
 
-$res = $data ~~ dpath('/report');
+$res = [ dpath('/report')->match($data) ];
 is($res->[0]{reportgroup_testrun_id}, 30862, "simple dpath" );
 
-$res = $data ~~ dpath('//data//benchmark[ value eq "call_simple"]/../mean/..');
+$res = [ dpath('//data//benchmark[ value eq "call_simple"]/../mean/..')->match($data) ];
 cmp_bag($res, [
                {
                 'glibc'              => 'glibc, 2.4',
@@ -68,10 +61,10 @@ $datacontent='';
 eval $datacontent;
 $data = $VAR1;
 
-$res = $data ~~ dpath('/report');
+$res = [ dpath('/report')->match($data) ];
 is($res->[0]{reportgroup_testrun_id}, 30862, "simple dpath 2" );
 
-$res = $data ~~ dpath('//data//benchmark[ value eq "xcall_simple"]/../mean/..');
+$res = [ dpath('//data//benchmark[ value eq "xcall_simple"]/../mean/..')->match($data) ];
 cmp_bag($res, [
                {
                 'glibc'              => 'xglibc, 2.4',

--- a/t/regressions.t
+++ b/t/regressions.t
@@ -2,7 +2,6 @@
 
 use strict;
 use warnings;
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
 
 use Test::More;
 use Test::Deep;
@@ -10,12 +9,6 @@ use Data::DPath 'dpath';
 use Data::Dumper;
 
 # local $Data::DPath::DEBUG = 1;
-
-BEGIN {
-        if ($] < 5.010) {
-                plan skip_all => "Perl 5.010 required for the smartmatch overloaded tests. This is ".$];
-        }
-}
 
 use feature 'say';
 
@@ -39,7 +32,7 @@ my $strange_data = {
     },
 };
 
-my $res = $data ~~ dpath '//*[ value =~ /i/ ]';
+my $res = [ dpath('//*[ value =~ /i/ ]')->match($data) ];
 my $expected = [ qw/split pie ii chips fries fish&chips/ ];
 unlike ($data->{aHash}, qr/i/, "RT-68882 - aHash does not match the regex");
 cmp_bag($res, $expected, "RT-68882 - elements with letter 'i' but not aHash");
@@ -47,7 +40,7 @@ cmp_bag($res, $expected, "RT-68882 - elements with letter 'i' but not aHash");
 # diag "expected = ".Dumper($expected);
 
 local $Data::DPath::USE_SAFE;
-$res = $data ~~ dpath '//*[ value =~ /i/ ]';
+$res = [ dpath('//*[ value =~ /i/ ]')->match($data) ];
 unlike ($data->{aHash}, qr/i/, "RT-68882 - aHash does not match the regex - again without Safe.pm");
 cmp_bag($res, $expected, "RT-68882 - elements with letter 'i' but not aHash - again without Safe.pm");
 
@@ -55,23 +48,23 @@ cmp_bag($res, $expected, "RT-68882 - elements with letter 'i' but not aHash - ag
 #  $data is not found with '//*' because
 #  the '*' always gets a *sub* element and
 #  therefore can never be the root element.
-$res = $data ~~ dpath '//*[ Scalar::Util::reftype(value) eq "HASH" ]';
+$res = [ dpath('//*[ Scalar::Util::reftype(value) eq "HASH" ]')->match($data) ];
 $expected = [ $data->{aHash} ];
 cmp_bag($res, $expected, "RT-68882 related - value filter function still works for hash");
 
-$res = $data ~~ dpath '//*[ Scalar::Util::reftype(value) eq "ARRAY" ]';
+$res = [ dpath('//*[ Scalar::Util::reftype(value) eq "ARRAY" ]')->match($data) ];
 $expected = [ $data->{aList}, $data->{aHash}{potato} ];
 cmp_bag($res, $expected, "RT-68882 related - value filter function still works for array");
 
 # github #24 - filter expressions with newlines
-$res = $strange_data ~~ dpath '/aHash/apple0[ value eq "pie" ]';
+$res = [ dpath('/aHash/apple0[ value eq "pie" ]')->match($strange_data) ];
 $expected = [ $strange_data->{aHash}{apple0} ];
 cmp_bag($res, $expected, "github 24 - filter expressions with newlines");
-$res = $strange_data ~~ dpath '/aHash/apple1[ value eq "apple pie" ]';
+$res = [ dpath('/aHash/apple1[ value eq "apple pie" ]')->match($strange_data) ];
 $expected = [ $strange_data->{aHash}{apple1} ];
 cmp_bag($res, $expected, "github 24 - filter expressions with newlines");
-$res = $strange_data ~~ dpath '/aHash/apple2[ value eq "apple
-pie" ]';
+$res = [ dpath('/aHash/apple2[ value eq "apple
+pie" ]')->match($strange_data) ];
 $expected = [ $strange_data->{aHash}{apple2} ];
 cmp_bag($res, $expected, "github 24 - filter expressions with newlines");
 

--- a/t/smartmatch.t
+++ b/t/smartmatch.t
@@ -1,0 +1,75 @@
+use strict;
+use warnings;
+use Test::More;
+BEGIN {
+    if ($] < 5.010 || $] >= 5.038 ) {
+        plan skip_all => "smartmatch overload tests require perl >= 5.10 and < 5.38. This is ".$];
+    }
+}
+
+no if $] >= 5.018, warnings => 'experimental::smartmatch';
+use Test::Deep;
+use Data::DPath 'dpath', 'dpathr';
+use Data::Dumper;
+
+# local $Data::DPath::DEBUG = 1;
+
+my $data = {
+            AAA  => { BBB   => { CCC  => [ qw/ XXX YYY ZZZ / ] },
+                      RRR   => { CCC  => [ qw/ RR1 RR2 RR3 / ] },
+                      DDD   => { EEE  => [ qw/ uuu vvv www / ] },
+                    },
+            some => { where => { else => {
+                                          AAA => { BBB => { CCC => 'affe' } },
+                                         } } },
+            strange_keys => { 'DD DD' => { 'EE/E' => { CCC => 'zomtec' } } },
+           };
+
+
+my $resultlist;
+
+cmp_bag($data ~~ dpath('/AAA/BBB/CCC'),    [ ['XXX', 'YYY', 'ZZZ'] ], "KEYs" );
+cmp_bag($data ~~ dpath('/AAA/BBB/CCC/..'), [ { CCC => ['XXX', 'YYY', 'ZZZ'] } ], "KEYs + PARENT" );
+cmp_bag($data ~~ dpath('/AAA/BBB/CCC/../..'), [
+                                                 {
+                                                  BBB => { CCC => ['XXX', 'YYY', 'ZZZ'] },
+                                                  RRR => { CCC  => [ qw/ RR1 RR2 RR3 / ] },
+                                                  DDD => { EEE => [ qw/ uuu vvv www / ] },
+                                                 }
+                                                ], "KEYs + PARENT + PARENT" );
+cmp_bag($data ~~ dpath('/AAA/BBB/CCC/../../DDD'), [ { EEE => [ qw/ uuu vvv www / ] } ], "KEYs + PARENT + KEY" );
+cmp_bag($data ~~ dpath('/AAA/*/CCC/../../DDD'), [ { EEE => [ qw/ uuu vvv www / ] } ], "KEYs + ANYSTEP + PARENT + KEY no double results" );
+cmp_bag($data ~~ dpath('/'), [ $data ], "ROOT" );
+cmp_bag($data ~~ dpath('/AAA/*/CCC'), [ ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "KEYs + ANYSTEP" );
+
+
+my $dpath = dpath('//AAA/*/CCC');
+$resultlist = $data ~~ $dpath;
+cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "ANYWHERE + KEYs + ANYSTEP with smartmatch and variable" );
+$dpath = dpath('///AAA/*/CCC');
+$resultlist = $data ~~ $dpath;
+cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "2xANYWHERE + KEYs + ANYSTEP with smartmatch and variable" );
+
+$resultlist = $data ~~ dpath('//AAA/*/CCC');
+cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "ANYWHERE + KEYs + ANYSTEP with smartmatch and dpath()" );
+$resultlist = $data ~~ dpath('///AAA/*/CCC');
+cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "2xANYWHERE + KEYs + ANYSTEP with smartmatch and dpath()" );
+
+$resultlist = $data ~~ dpathr('///AAA/*/CCC');
+cmp_bag($resultlist, [ \($data->{some}{where}{else}{AAA}{BBB}{CCC}),
+                       \($data->{AAA}{BBB}{CCC}),
+                       \($data->{AAA}{RRR}{CCC}),
+                     ], "2xANYWHERE + KEYs + ANYSTEP with smartmatch and dpath() (REFERENCES)" );
+
+
+$resultlist = $data ~~ dpath '//AAA/*/CCC';
+cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "ANYWHERE + KEYs + ANYSTEP with smartmatch and dpath without parens" );
+$resultlist = $data ~~ dpath '///AAA/*/CCC';
+cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "2xANYWHERE + KEYs + ANYSTEP with smartmatch and dpath without parens" );
+
+$resultlist = $data ~~ dpath '//AAA/*/CCC';
+cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "ANYWHERE + KEYs + ANYSTEP with smartmatch and dpath without parens commutative" );
+$resultlist = $data ~~ dpath '///AAA/*/CCC';
+cmp_bag($resultlist, [ 'affe', ['XXX', 'YYY', 'ZZZ'], [ 'RR1', 'RR2', 'RR3' ] ], "2xANYWHERE + KEYs + ANYSTEP with smartmatch and dpath without parens commutative" );
+
+done_testing;

--- a/t/zeros.t
+++ b/t/zeros.t
@@ -2,7 +2,6 @@
 
 use strict;
 use warnings;
-no if $] >= 5.018, warnings => 'experimental::smartmatch';
 
 use Test::More;
 use Test::Deep;
@@ -10,12 +9,6 @@ use Data::DPath 'dpath';
 use Data::Dumper;
 
 # local $Data::DPath::DEBUG = 1;
-
-BEGIN {
-        if ($] < 5.010) {
-                plan skip_all => "Perl 5.010 required for the smartmatch overloaded tests. This is ".$];
-        }
-}
 
 use_ok( 'Data::DPath' );
 
@@ -40,31 +33,31 @@ my $data = {
 
 my $res;
 
-$res = $data ~~ dpath '//goal[ value == 15]';
+$res = [ dpath('//goal[ value == 15]')->match($data) ];
 cmp_bag($res, [ 15 ], "leaf with value");
 
-$res = $data ~~ dpath '//goal';
+$res = [ dpath('//goal')->match($data) ];
 cmp_bag($res, [ 15, 0, undef ], "many leafs with value");
 
-$res = $data ~~ dpath '//goal[value == 15]/../data_size';
+$res = [ dpath('//goal[value == 15]/../data_size')->match($data) ];
 cmp_bag($res, [ 254242 ], "data_size via leaf");
 
-$res = $data ~~ dpath '//goal[ value eq 0 ]';
+$res = [ dpath('//goal[ value eq 0 ]')->match($data) ];
 cmp_bag($res, [ 0 ], "leaf of value 0");
 
-$res = $data ~~ dpath '//goal[value eq 0]/../count';
+$res = [ dpath('//goal[value eq 0]/../count')->match($data) ];
 cmp_bag($res, [ "zero" ], "data_size via leaf of value 0");
 
-$res = $data ~~ dpath '//goal[ value eq undef ]';
+$res = [ dpath('//goal[ value eq undef ]')->match($data) ];
 cmp_bag($res, [ undef ], "leaf of value undef");
 
-$res = $data ~~ dpath '//goal[ value eq undef ]/../count';
+$res = [ dpath('//goal[ value eq undef ]/../count')->match($data) ];
 cmp_bag($res, [ "UNDEF" ], "data_size via leaf of value undef");
 
-$res = $data ~~ dpath '/normal/normal/goal';
+$res = [ dpath('/normal/normal/goal')->match($data) ];
 cmp_bag($res, [ 15 ], "absolute path - leaf with value");
 
-$res = $data ~~ dpath '/zero/goal';
+$res = [ dpath('/zero/goal')->match($data) ];
 cmp_bag($res, [ 0 ], "absolute path - leaf of value 0");
 
 done_testing();


### PR DESCRIPTION
Smartmatch is deprecated in newer perls. Move the tests that are explicitly checking the smartmatch behavior to their own script with appropriate skips, and convert the rest to use the match method.